### PR TITLE
note service: lazy load notes. Fixes #37

### DIFF
--- a/js/app/services/NoteService.js
+++ b/js/app/services/NoteService.js
@@ -43,14 +43,10 @@
 				getNoteById: function(noteId) {
 					noteId = parseInt(noteId);
 					var deferred = $q.defer();
-					if ($rootScope.notes && $rootScope.notes.hasOwnProperty(noteId)) {
-						deferred.resolve(new NoteFactory($rootScope.notes[noteId]));
-					} else {
-						NoteFactory.get({id: noteId}, function(note) {
-							$rootScope.notes[note.id] = note;
-							deferred.resolve(note);
-						});
-					}
+					NoteFactory.get({id: noteId}, function(note) {
+						$rootScope.notes[note.id] = note;
+						deferred.resolve(note);
+					});
 					return deferred.promise;
 				},
 				save: NoteFactory.save,

--- a/lib/Db/NextNoteMapper.php
+++ b/lib/Db/NextNoteMapper.php
@@ -64,6 +64,13 @@ class NextNoteMapper extends Mapper {
 			 * @var $note NextNote
 			 */
 			$note = $this->makeEntityFromDBResult($item);
+			/* fetch note parts */
+			$noteParts = $this->getNoteParts($note);
+			$partsTxt = implode('', array_map(function ($part) {
+				return $part['note'];
+			}, $noteParts));
+			$note->setNote($arr['note'] . $partsTxt);
+
 			$results[] = $note;
 		}
 		return array_shift($results);
@@ -215,11 +222,6 @@ class NextNoteMapper extends Mapper {
 		$note->setMtime($arr['mtime']);
 		$note->setDeleted($arr['deleted']);
 		$note->setUid($arr['uid']);
-		$noteParts = $this->getNoteParts($note);
-		$partsTxt = implode('', array_map(function ($part) {
-			return $part['note'];
-		}, $noteParts));
-		$note->setNote($arr['note'] . $partsTxt);
 		return $note;
 	}
 }

--- a/lib/Db/NextNoteMapper.php
+++ b/lib/Db/NextNoteMapper.php
@@ -69,7 +69,7 @@ class NextNoteMapper extends Mapper {
 			$partsTxt = implode('', array_map(function ($part) {
 				return $part['note'];
 			}, $noteParts));
-			$note->setNote($arr['note'] . $partsTxt);
+			$note->setNote($item['note'] . $partsTxt);
 
 			$results[] = $note;
 		}


### PR DESCRIPTION
Previously fetching a list of notes eagerly loaded
all note parts, this could lead to the whole fetch
failing for large notebooks when the fetch is
interrupted either by reaching a request timeout
or hitting a transfer limit. This was observed
in the wild on a notebook containing 702 notes which
failed to load after hitting 7 MB on the wire in over
1 minute.

To resolve the problem we don't rely on the loaded
list of notes when acting upon a single note. Instead
we always hit the single note 'find' endpoint re-fetching
the note and its parts. We also remove the parts fetching
from the 'findNotesFromUser' path responsible for providing
the index of notes.

On top of fixing the problem this greatly speeds up obtaining
the list of notes for the cost of additional small requests
when accessing specific notes.

Signed-off-by: Adam Wolk <adam.wolk@tintagel.pl>