### PR TITLE
Fix missing permission checks when accessing or deleting notes and no…

### DIFF
--- a/controller/settingscontroller.php
+++ b/controller/settingscontroller.php
@@ -29,15 +29,12 @@ use OCP\IRequest;
 use OCA\NextNote\Service\SettingsService;
 
 class SettingsController extends ApiController {
-	private $userId;
 	private $settings;
 
 	public function __construct(
 		$AppName,
 		IRequest $request,
-		$userId,
-		SettingsService $settings,
-		IL10N $l) {
+		SettingsService $settings) {
 		parent::__construct(
 			$AppName,
 			$request,
@@ -45,8 +42,6 @@ class SettingsController extends ApiController {
 			'Authorization, Content-Type, Accept',
 			86400);
 		$this->settings = $settings;
-		$this->l = $l;
-		$this->userId = $userId;
 	}
 
 


### PR DESCRIPTION
…tebooks.

There were no checks to make sure that a user can only access or delete their own notes / notebooks. Notes of other users can be accessed or deleted by simple URL rewriting (e.g. by tunneling through a proxy). This is especially easy because the notes' and notebooks' IDs are enumerable and therefore can be guessed by decrementing / incrementing a known ID.

I made sure to always pass the current user's ID when looking up notes and notebooks from the DB. I'm sure this has to be converted into something more sophisticated once sharing is in, depending on the implementation, but for now it should prevent illegal access.